### PR TITLE
chore: Reorder startup commands to make database migrations possible

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -34,7 +34,10 @@ RUN install-php-extensions \
 COPY .docker/start-container /usr/local/bin/start-container
 COPY .docker/php-conf/opcache.ini /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini
 
-RUN apt update -y && apt upgrade -y && apt install -y procps
+RUN apt update -y \
+    && apt upgrade -y \
+    && apt install --no-install-recommends -y procps \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -32,7 +32,7 @@ RUN install-php-extensions \
     redis
 
 COPY .docker/start-container /usr/local/bin/start-container
-COPY .docker/conf.d/opcache.ini /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini
+COPY .docker/php-conf/opcache.ini /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini
 
 RUN apt update -y && apt upgrade -y && apt install -y procps
 

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -6,15 +6,22 @@ FROM node:${NODE_VERSION} AS node
 
 WORKDIR /app
 
+COPY package*.json .
+
+RUN npm ci
+
 COPY . .
 
-RUN npm ci && npm run build
+RUN npm run build
 
 FROM composer:${COMPOSER_VERSION} AS vendor
 
-FROM dunglas/frankenphp:1.7-php${PHP_VERSION}
+FROM dunglas/frankenphp:1.8-php${PHP_VERSION}
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG COMPOSER_FLAGS=--no-dev
+
+ENV WWWGROUP=nobody
 
 RUN install-php-extensions \
     pcntl \
@@ -24,17 +31,22 @@ RUN install-php-extensions \
     exif \
     redis
 
-COPY --from=vendor /usr/bin/composer /usr/bin/
-COPY .docker/php-conf/opcache.ini /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini
 COPY .docker/start-container /usr/local/bin/start-container
-COPY . /app
-COPY --from=node /app/public /app/public
+COPY .docker/conf.d/opcache.ini /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini
+
+RUN apt update -y && apt upgrade -y && apt install -y procps
 
 WORKDIR /app
 
+COPY --from=vendor /usr/bin/composer /usr/bin/
+COPY --from=node /app/public /app/public/
+
+COPY . .
+
 # The config:cache command is executed at runtime to load environment variables.
-RUN composer install --no-interaction --optimize-autoloader --no-dev \
+RUN composer install --no-interaction --optimize-autoloader $COMPOSER_FLAGS \
     && php artisan storage:link \
-    && php artisan optimize
+    && php artisan optimize \
+    && php artisan icons:cache
 
 ENTRYPOINT ["start-container"]

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -50,6 +50,6 @@ COPY . .
 RUN composer install --no-interaction --optimize-autoloader $COMPOSER_FLAGS \
     && php artisan storage:link \
     && php artisan optimize \
-    && php artisan icons:cache
+    && php artisan filament:optimize
 
 ENTRYPOINT ["start-container"]

--- a/.docker/start-container
+++ b/.docker/start-container
@@ -12,7 +12,6 @@ fi
 
 if [ $# -gt 0 ]; then
     exec "$@"
-    exit 0
 fi
 
 # Non-interactive migration. Will continue to run the app when migration fails.

--- a/.docker/start-container
+++ b/.docker/start-container
@@ -5,17 +5,18 @@ set -e
 role=${CONTAINER_ROLE:-app}
 env=${APP_ENV:-production}
 
-if [ $# -gt 0 ]; then
-    exec "$@"
-fi
-
-# Non-interactive migration. Will continue to run the app when migration fails.
-php artisan migrate --force --no-interaction --step --isolated=true || true
-
 if [ "$env" != "local" ]; then
     echo "Caching configuration..."
     php artisan config:cache
 fi
+
+if [ $# -gt 0 ]; then
+    exec "$@"
+    exit 0
+fi
+
+# Non-interactive migration. Will continue to run the app when migration fails.
+php artisan migrate --force --no-interaction --step --isolated=true || true
 
 if [ "$role" = "app" ]; then
 


### PR DESCRIPTION
The order of commands in the start-container script is wrong. It will always try to connect to an sqlite database even though a postgresql database server was configured. I've also restructured the image a bit and removed some redundant commands.